### PR TITLE
NF: LinkedList pop()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export {LinkedList} from "./lib/LinkedList";
+export {LinkedList, ListNode} from "./lib/LinkedList";

--- a/lib/LinkedList.ts
+++ b/lib/LinkedList.ts
@@ -1,8 +1,9 @@
 /**
  * Node for LinkedList
- * @internal
+ * @public
+ * @since 0.0.0
  */
-class ListNode<T> {
+export class ListNode<T> {
 	/**
    * the value of the Node
    */
@@ -409,5 +410,44 @@ export class LinkedList<T> {
 			idx++;
 			currentNode = currentNode.next;
 		}
+	}
+	/**
+   * The pop() method removes the last element from an LinkedList and returns that element.
+   * This method changes the length of the LinkedList.
+   * ```ts
+   * const plants = new LinkedList('broccoli', 'cauliflower', 'cabbage', 'kale', 'tomato')
+   * console.log(plants.pop().value);
+   * // expected output: "tomato"
+   * 
+   * console.log(plants.toArray());
+   * // expected output: Array ["broccoli", "cauliflower", "cabbage", "kale"]
+   * 
+   * plants.pop();
+   * 
+   * console.log(plants.toArray());
+   * // expected output: Array ["broccoli", "cauliflower", "cabbage"]
+   * ```
+   * 
+   * @public
+   * @since 0.2.0-alpha
+   */
+	pop(): ListNode<T> | undefined {
+		let poped = undefined;
+		if (this.length === 0) {
+			return poped;
+		} else if (this.length === 1) {
+			poped = this.head;
+			this.length = 0;
+			this.tail = null;
+			this.head = null;
+		} else {
+			poped = this.tail;
+			this.length--;
+			this.tail = this.tail.prev;
+			this.tail.next = null;
+			poped.prev = null;
+		}
+
+		return poped;
 	}
 }

--- a/test/LinkedList/pop.spec.ts
+++ b/test/LinkedList/pop.spec.ts
@@ -1,0 +1,26 @@
+import {LinkedList, ListNode} from "../../index";
+import {expect} from "chai";
+
+describe(
+	"LinkedList - pop",
+	() => {
+		it(
+			"should pop the last element",
+			() => {
+				const list = new LinkedList(1, 2, 3, 4);
+				const poped = list.pop();
+				expect(poped).deep.eq(new ListNode(4));
+				expect(list).deep.eq(new LinkedList(1, 2, 3));
+				expect(list.length).eq(3);
+			},
+		);
+
+		it(
+			"pop empty list should return undefined",
+			() => {
+				const list = new LinkedList();
+				expect(list.pop()).eq(undefined);
+			},
+		);
+	},
+);


### PR DESCRIPTION
implement `.pop()` method, using the same spec as standard Array